### PR TITLE
Feature/#38 issue travis back compat

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: csharp
 sudo: required
 mono: none
-dotnet: 1.0.3
+dotnet: 1.0.4
 dist: trusty
 addons:
   apt:

--- a/src/Contentment.Api/Dockerfile
+++ b/src/Contentment.Api/Dockerfile
@@ -7,11 +7,11 @@ RUN dotnet restore
 
 # Copy everything else and build
 COPY . .
-RUN dotnet publish --output /app/ --configuration Release
+RUN dotnet publish --output /source/ --configuration Release
 
 # Build runtime image
 FROM microsoft/aspnetcore:1.1
 WORKDIR /app
 LABEL MAINTAINER="baynezy@gmail.com"
-COPY --from=build-env /app .
+COPY --from=build-env /source .
 ENTRYPOINT ["dotnet", "Contentment.Api.dll"]


### PR DESCRIPTION
Fix backwards compatibility issue with Travis
Travis upgraded some components and left no backwards compatibilty
in their build. So we needed to upgrade to make builds work again.

travis-ci/travis-ci#8793

Fixes #38