### PR TITLE
Fix incorrect Content Types in /content responses

### DIFF
--- a/src/Contentment.Api/Controllers/ContentController.cs
+++ b/src/Contentment.Api/Controllers/ContentController.cs
@@ -23,6 +23,7 @@ namespace Contentment.Api.Controllers {
 				var newContent = _contentService.Create(content);
 				result = Json(newContent);
 				result.StatusCode = (int)HttpStatusCode.Created;
+				result.ContentType = ContentTypes.VENDOR_MIME_TYPE;
 			}
 			else {
 				var error = new ClientError(ModelState){
@@ -31,6 +32,7 @@ namespace Contentment.Api.Controllers {
 				};
 				result = Json(error);
 				result.StatusCode = (int)HttpStatusCode.BadRequest;
+				result.ContentType = ContentTypes.VENDOR_MIME_TYPE_ERROR;
 			}
 
 			return result;

--- a/src/Contentment.Api/Domain/ContentTypes.cs
+++ b/src/Contentment.Api/Domain/ContentTypes.cs
@@ -1,0 +1,8 @@
+namespace Contentment.Api.Domain
+{
+	public class ContentTypes
+	{
+		public static readonly string VENDOR_MIME_TYPE = "application/vnd+contentment+json";
+		public static readonly string VENDOR_MIME_TYPE_ERROR = "application/vnd+contentment-exception+json";
+	}
+}

--- a/test/Contentment.Api.IntegrationTest/Controllers/ContentControllerTest.cs
+++ b/test/Contentment.Api.IntegrationTest/Controllers/ContentControllerTest.cs
@@ -5,6 +5,7 @@ using Contentment.Api.Model;
 using Newtonsoft.Json;
 using NUnit.Framework;
 using Contentment.Api.Test.Helpers;
+using Contentment.Api.Domain;
 
 namespace Contentment.Api.IntegrationTest.Controllers {
 	[TestFixture]
@@ -21,6 +22,32 @@ namespace Contentment.Api.IntegrationTest.Controllers {
 			Assert.That(json.body.ToString(), Is.EqualTo(validContent.Body));
 			Assert.That(json.id, Is.Not.Null);
 			Assert.That(json.createdDateTime, Is.Not.Null);
+		}
+
+		[Test]
+		public async Task PostContent_WhenCalledWithValidContent_ThenShouldReturnVendorContentType() {
+			var validContent = ContentHelper.ValidContent();
+			//TODO: Fix in https://github.com/contentment-dot-io/contentment.api/issues/43
+			var content = new StringContent(JsonConvert.SerializeObject(validContent), Encoding.UTF8, "application/json");
+			var response = await GetClient().PostAsync("/content", content);
+
+			var headers = response.Content.Headers;
+
+			Assert.That(headers.Contains("Content-Type"), Is.True);
+			Assert.That(headers.ContentType.MediaType, Is.EqualTo(ContentTypes.VENDOR_MIME_TYPE));
+		}
+
+		[Test]
+		public async Task PostContent_WhenCalledWithInvalidContent_ThenShouldReturnVendorContentType() {
+			var validContent = ContentHelper.InvalidContent();
+			//TODO: Fix in https://github.com/contentment-dot-io/contentment.api/issues/43
+			var content = new StringContent(JsonConvert.SerializeObject(validContent), Encoding.UTF8, "application/json");
+			var response = await GetClient().PostAsync("/content", content);
+
+			var headers = response.Content.Headers;
+
+			Assert.That(headers.Contains("Content-Type"), Is.True);
+			Assert.That(headers.ContentType.MediaType, Is.EqualTo(ContentTypes.VENDOR_MIME_TYPE_ERROR));
 		}
 	}
 }

--- a/test/Contentment.Api.IntegrationTest/Controllers/InfoControllerTest.cs
+++ b/test/Contentment.Api.IntegrationTest/Controllers/InfoControllerTest.cs
@@ -1,4 +1,5 @@
 using System.Threading.Tasks;
+using Contentment.Api.Domain;
 using NUnit.Framework;
 
 namespace Contentment.Api.IntegrationTest.Controllers
@@ -13,7 +14,7 @@ namespace Contentment.Api.IntegrationTest.Controllers
 			var headers = response.Content.Headers;
 
 			Assert.That(headers.Contains("Content-Type"), Is.True);
-			Assert.That(headers.ContentType.MediaType, Is.EqualTo("application/vnd+contentment+json"));
+			Assert.That(headers.ContentType.MediaType, Is.EqualTo(ContentTypes.VENDOR_MIME_TYPE));
 		}
 	}
 }


### PR DESCRIPTION
/content was returning the default media type. Now it is valid with the
specification. The Accept header is still broken and will need resolving
in #43

Fixes #42