### PR TITLE
Add vendor specific MimeType support on HTTP POST

### DIFF
--- a/src/Contentment.Api/Startup.cs
+++ b/src/Contentment.Api/Startup.cs
@@ -6,9 +6,11 @@ using Contentment.Api.Domain;
 using Contentment.Api.Services;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Formatters;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.Net.Http.Headers;
 
 namespace Contentment.Api
 {
@@ -35,7 +37,13 @@ namespace Contentment.Api
 			services.AddTransient<IIdGenerator, GuidIdGenerator>();
 
             // Add framework services.
-            services.AddMvc();
+            services.AddMvc(
+				mvcConfig => {
+					mvcConfig.InputFormatters.OfType<JsonInputFormatter>().First().SupportedMediaTypes.Add(
+						MediaTypeHeaderValue.Parse(ContentTypes.VENDOR_MIME_TYPE)
+					);
+				}
+			);
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/test/Contentment.Api.IntegrationTest/Controllers/ContentControllerTest.cs
+++ b/test/Contentment.Api.IntegrationTest/Controllers/ContentControllerTest.cs
@@ -13,7 +13,7 @@ namespace Contentment.Api.IntegrationTest.Controllers {
 		[Test]
 		public async Task PostContent_WhenCalledWithValidContent_ThenShouldReturnCreatedContent() {
 			var validContent = ContentHelper.ValidContent();
-			var content = new StringContent(JsonConvert.SerializeObject(validContent), Encoding.UTF8, "application/json");
+			var content = new StringContent(JsonConvert.SerializeObject(validContent), Encoding.UTF8, ContentTypes.VENDOR_MIME_TYPE);
 			var response = await GetClient().PostAsync("/content", content);
 			var jsonString = await response.Content.ReadAsStringAsync();
 			dynamic json = JsonConvert.DeserializeObject(jsonString);
@@ -27,8 +27,7 @@ namespace Contentment.Api.IntegrationTest.Controllers {
 		[Test]
 		public async Task PostContent_WhenCalledWithValidContent_ThenShouldReturnVendorContentType() {
 			var validContent = ContentHelper.ValidContent();
-			//TODO: Fix in https://github.com/contentment-dot-io/contentment.api/issues/43
-			var content = new StringContent(JsonConvert.SerializeObject(validContent), Encoding.UTF8, "application/json");
+			var content = new StringContent(JsonConvert.SerializeObject(validContent), Encoding.UTF8, ContentTypes.VENDOR_MIME_TYPE);
 			var response = await GetClient().PostAsync("/content", content);
 
 			var headers = response.Content.Headers;
@@ -40,8 +39,7 @@ namespace Contentment.Api.IntegrationTest.Controllers {
 		[Test]
 		public async Task PostContent_WhenCalledWithInvalidContent_ThenShouldReturnVendorContentType() {
 			var validContent = ContentHelper.InvalidContent();
-			//TODO: Fix in https://github.com/contentment-dot-io/contentment.api/issues/43
-			var content = new StringContent(JsonConvert.SerializeObject(validContent), Encoding.UTF8, "application/json");
+			var content = new StringContent(JsonConvert.SerializeObject(validContent), Encoding.UTF8, ContentTypes.VENDOR_MIME_TYPE);
 			var response = await GetClient().PostAsync("/content", content);
 
 			var headers = response.Content.Headers;


### PR DESCRIPTION
Previously I could not get vendor specific mimetypes to work with HTTP
POST operations.

Fixes #43 